### PR TITLE
Process memcycle is a responsibility of report error

### DIFF
--- a/otherlibs/action-plugin/test/depends-on-its-target-by-read-dir/run.t
+++ b/otherlibs/action-plugin/test/depends-on-its-target-by-read-dir/run.t
@@ -15,6 +15,7 @@
   $ dune build some_file
   Error: Dependency cycle between:
      _build/default/some_file
+  -> required by _build/default/some_file
   [1]
 
 ^ This is not great. There is no actual dependency cycle, dune is just

--- a/otherlibs/action-plugin/test/depends-on-its-target/run.t
+++ b/otherlibs/action-plugin/test/depends-on-its-target/run.t
@@ -21,9 +21,11 @@
   $ dune build some_file1
   Error: Dependency cycle between:
      _build/default/some_file1
+  -> required by _build/default/some_file1
   [1]
 
   $ dune build some_file2
   Error: Dependency cycle between:
      _build/default/some_file2
+  -> required by _build/default/some_file2
   [1]

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -2288,32 +2288,6 @@ open Exported
 
 let eval_pred = Pred.eval
 
-let process_memcycle (cycle_error : Memo.Cycle_error.t) =
-  let cycle =
-    Memo.Cycle_error.get cycle_error
-    |> List.filter_map ~f:Memo.Stack_frame.human_readable_description
-  in
-  match List.last cycle with
-  | None ->
-    let frames = Memo.Cycle_error.get cycle_error in
-    Code_error.E
-      (Code_error.create "internal dependency cycle"
-         [ ("frames", Dyn.Encoder.(list Memo.Stack_frame.to_dyn) frames) ])
-  | Some last ->
-    let first = List.hd cycle in
-    let cycle =
-      if last = first then
-        cycle
-      else
-        last :: cycle
-    in
-    User_error.E
-      ( User_error.make
-          [ Pp.text "Dependency cycle between:"
-          ; Pp.chain cycle ~f:(fun p -> p)
-          ]
-      , [] )
-
 let package_deps ~packages_of (pkg : Package.t) files =
   let rules_seen = ref Rule.Set.empty in
   let rec loop fn =
@@ -2354,18 +2328,7 @@ let prefix_rules (prefix : unit Action_builder.t) ~f =
 
 module Alias = Alias0
 
-let process_exn exn =
-  Exn_with_backtrace.map exn ~f:(fun exn ->
-      match exn with
-      | Memo.Cycle_error.E cycle_error -> process_memcycle cycle_error
-      | Memo.Error.E e -> (
-        match Memo.Error.get e with
-        | Memo.Cycle_error.E cycle_error -> process_memcycle cycle_error
-        | _ -> exn)
-      | _ -> exn)
-
-let process_exn_and_report exn =
-  let exn = process_exn exn in
+let report_early_exn exn =
   let t = t () in
   t.errors <- exn :: t.errors;
   (match !Clflags.report_errors_config with
@@ -2375,12 +2338,11 @@ let process_exn_and_report exn =
   | Deterministic -> ());
   t.handler.error [ Add exn ]
 
-let process_exn_and_reraise exn =
+let reraise_exn exn =
   match !Clflags.report_errors_config with
   | Early -> raise Dune_util.Report_error.Already_reported
   | Twice
   | Deterministic ->
-    let exn = process_exn exn in
     Exn_with_backtrace.reraise exn
 
 let run f =
@@ -2397,9 +2359,9 @@ let run f =
   let f () =
     let* () = t.handler.build_event Start in
     let* res =
-      Fiber.with_error_handler ~on_error:process_exn_and_reraise (fun () ->
+      Fiber.with_error_handler ~on_error:reraise_exn (fun () ->
           Memo.Build.run_with_error_handler (f ())
-            ~handle_error_no_raise:process_exn_and_report)
+            ~handle_error_no_raise:report_early_exn)
     in
     let+ () = t.handler.build_event Finish in
     res

--- a/src/dune_util/report_error.ml
+++ b/src/dune_util/report_error.ml
@@ -6,25 +6,47 @@ type who_is_responsible_for_the_error =
   | User
   | Developer
 
-let get_user_message = function
-  | User_error.E (msg, _) -> (User, msg)
+type error =
+  { responsible : who_is_responsible_for_the_error
+  ; msg : User_message.t
+  ; has_embedded_location : bool
+  }
+
+let get_error_from_exn = function
+  | Memo.Error.E _
+  | Already_reported ->
+    (* should be handled by the caller *)
+    assert false
+  | User_error.E (msg, annots) ->
+    let has_embedded_location = User_error.has_embed_location annots in
+    { responsible = User; msg; has_embedded_location }
   | Code_error.E e ->
     let open Pp.O in
-    ( Developer
-    , User_message.make ?loc:e.loc
-        [ Pp.tag User_message.Style.Error
-            (Pp.textf
-               "Internal error, please report upstream including the contents \
-                of _build/log.")
-        ; Pp.text "Description:"
-        ; Pp.box ~indent:2
-            (Pp.verbatim "  " ++ Dyn.pp (Code_error.to_dyn_without_loc e))
-        ] )
+    { responsible = Developer
+    ; msg =
+        User_message.make ?loc:e.loc
+          [ Pp.tag User_message.Style.Error
+              (Pp.textf
+                 "Internal error, please report upstream including the \
+                  contents of _build/log.")
+          ; Pp.text "Description:"
+          ; Pp.box ~indent:2
+              (Pp.verbatim "  " ++ Dyn.pp (Code_error.to_dyn_without_loc e))
+          ]
+    ; has_embedded_location = false
+    }
   | Unix.Unix_error (err, func, fname) ->
-    ( User
-    , User_error.make
-        [ Pp.textf "%s: %s: %s" func fname (Unix.error_message err) ] )
-  | Sys_error msg -> (User, User_error.make [ Pp.text msg ])
+    { responsible = User
+    ; msg =
+        User_error.make
+          [ Pp.textf "%s: %s: %s" func fname (Unix.error_message err) ]
+    ; has_embedded_location = false
+    }
+  | Sys_error msg ->
+    { responsible = User
+    ; msg = User_error.make [ Pp.text msg ]
+    ; has_embedded_location = false
+    }
   | exn ->
     let open Pp.O in
     let s = Printexc.to_string exn in
@@ -41,7 +63,10 @@ let get_user_message = function
         let stop = { start with pos_cnum = stop } in
         (Some { Loc.start; stop }, Pp.text s)
     in
-    (Developer, User_message.make ?loc [ pp ])
+    { responsible = Developer
+    ; msg = User_message.make ?loc [ pp ]
+    ; has_embedded_location = Option.is_some loc
+    }
 
 let i_must_not_crash =
   let reported = ref false in
@@ -76,12 +101,7 @@ let report { Exn_with_backtrace.exn; backtrace } =
   match exn with
   | Already_reported -> ()
   | _ ->
-    let who_is_responsible, msg = get_user_message exn in
-    let has_embed_location =
-      match exn with
-      | User_error.E (_, annots) -> User_error.has_embed_location annots
-      | _ -> false
-    in
+    let { responsible; msg; has_embedded_location } = get_error_from_exn exn in
     let msg =
       if msg.loc = Some Loc.none then
         { msg with loc = None }
@@ -92,7 +112,7 @@ let report { Exn_with_backtrace.exn; backtrace } =
       { msg with paragraphs = msg.paragraphs @ pp }
     in
     let msg =
-      if who_is_responsible = User && not !report_backtraces_flag then
+      if responsible = User && not !report_backtraces_flag then
         msg
       else
         append msg
@@ -106,7 +126,7 @@ let report { Exn_with_backtrace.exn; backtrace } =
       else
         match msg.loc with
         | None ->
-          if has_embed_location then
+          if has_embedded_location then
             []
           else
             memo_stack
@@ -139,7 +159,7 @@ let report { Exn_with_backtrace.exn; backtrace } =
       | Some pp -> append msg [ pp ]
     in
     let msg =
-      match who_is_responsible with
+      match responsible with
       | User -> msg
       | Developer -> append msg (i_must_not_crash ())
     in

--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -97,8 +97,8 @@ end
 module Spec = struct
   type ('i, 'o) t =
     { name : string option
-    ; (* If the field [witness] precedes any of the functional values ([input] and [f]),
-         then polymorphic comparison actually works for [Spec.t]s. *)
+    ; (* If the field [witness] precedes any of the functional values ([input]
+         and [f]), then polymorphic comparison actually works for [Spec.t]s. *)
       witness : 'i Type_eq.Id.t
     ; input : (module Store_intf.Input with type t = 'i)
     ; allow_cutoff : 'o Allow_cutoff.t
@@ -145,10 +145,10 @@ end
 module Dep_node_without_state = struct
   type ('i, 'o) t =
     { id : Id.t
-    (* If [id] is placed first in this data structhre, then polymorphic comparison
-       for dep nodes works fine regardless of the other fields.
-       (at the moment polymorphic comparison is used for Exn_set, but we're hoping
-       to change that) *)
+          (* If [id] is placed first in this data structhre, then polymorphic
+             comparison for dep nodes works fine regardless of the other fields.
+             (at the moment polymorphic comparison is used for Exn_set, but
+             we're hoping to change that) *)
     ; spec : ('i, 'o) Spec.t
     ; input : 'i
     }

--- a/test/blackbox-tests/test-cases/loop.t/run.t
+++ b/test/blackbox-tests/test-cases/loop.t/run.t
@@ -3,6 +3,8 @@
      _build/default/a
   -> _build/default/b
   -> _build/default/a
+  -> required by _build/default/b
+  -> required by _build/default/a
   [1]
 
 This second example is slightly more complicated as we request result1
@@ -14,6 +16,9 @@ does show a cycle.
      _build/default/result2
   -> _build/default/input
   -> _build/default/result2
+  -> required by _build/default/result2
+  -> required by _build/default/input
+  -> required by _build/default/result1
   [1]
 
   $ dune build result1 --debug-dependency-path
@@ -21,4 +26,7 @@ does show a cycle.
      _build/default/result2
   -> _build/default/input
   -> _build/default/result2
+  -> required by _build/default/result2
+  -> required by _build/default/input
+  -> required by _build/default/result1
   [1]

--- a/test/blackbox-tests/test-cases/reporting-of-cycles.t/run.t
+++ b/test/blackbox-tests/test-cases/reporting-of-cycles.t/run.t
@@ -9,6 +9,8 @@ the second run of dune.
      alias a/.a-files
   -> alias b/.b-files
   -> alias a/.a-files
+  -> required by alias a/.a-files
+  -> required by alias package-cycle in dune:1
   [1]
 
   $ dune build @simple-repro-case
@@ -16,6 +18,8 @@ the second run of dune.
      _build/default/x
   -> _build/default/y
   -> _build/default/x
+  -> required by _build/default/y
+  -> required by alias simple-repro-case in dune:5
   [1]
 
   $ dune build x1
@@ -23,6 +27,9 @@ the second run of dune.
      _build/default/x2
   -> _build/default/x3
   -> _build/default/x2
+  -> required by _build/default/x3
+  -> required by _build/default/x2
+  -> required by _build/default/x1
   [1]
 
   $ dune build @complex-repro-case
@@ -32,6 +39,9 @@ the second run of dune.
   -> _build/default/cd3
   -> _build/default/cd2
   -> _build/default/cd1
+  -> required by _build/default/cd4
+  -> required by _build/default/cd3
+  -> required by alias complex-repro-case in dune:22
   [1]
 
 In some cases the dependencies are indirect (#666, #2818).
@@ -60,4 +70,9 @@ cryptic and can involve unrelated files:
   -> _build/default/indirect/.a.eobjs/b.impl.all-deps
   -> _build/default/indirect/.a.eobjs/c.intf.all-deps
   -> _build/default/indirect/.a.eobjs/a.impl.all-deps
+  -> required by _build/default/indirect/.a.eobjs/b.impl.all-deps
+  -> required by _build/default/indirect/.a.eobjs/c.intf.all-deps
+  -> required by _build/default/indirect/.a.eobjs/a.impl.all-deps
+  -> required by _build/default/indirect/a.exe
+  -> required by alias indirect/indirect-deps in indirect/dune:6
   [1]

--- a/test/expect-tests/memo/memoize_tests.ml
+++ b/test/expect-tests/memo/memoize_tests.ml
@@ -39,9 +39,8 @@ let run_and_log_errors m =
   | Ok res -> res
   | Error exns ->
     List.iter exns ~f:(fun exn ->
-      Format.printf "Error: %a@." Pp.to_fmt
-        (Dyn.pp (Exn_with_backtrace.to_dyn exn))
-    )
+        Format.printf "Error: %a@." Pp.to_fmt
+          (Dyn.pp (Exn_with_backtrace.to_dyn exn)))
 
 (* the trivial dependencies are simply the identity function *)
 let compdep x = Memo.Build.return (x ^ x)
@@ -1193,34 +1192,25 @@ let%expect_test "deadlocks when creating a cycle twice" =
 
 let lazy_rec f =
   let fdecl = Fdecl.create (fun _ -> Dyn.Opaque) in
-  let node =
-    Memo.Lazy.create (fun () ->
-      f (Fdecl.get fdecl))
-  in
+  let node = Memo.Lazy.create (fun () -> f (Fdecl.get fdecl)) in
   Fdecl.set fdecl node;
   node
 
 let%expect_test "two similar, but not physically-equal, cycle errors" =
-  let cycle1 =
-    lazy_rec (fun node ->
-      Memo.Lazy.force node)
-  in
-  let cycle2 =
-    lazy_rec (fun node ->
-      Memo.Lazy.force node)
-  in
+  let cycle1 = lazy_rec (fun node -> Memo.Lazy.force node) in
+  let cycle2 = lazy_rec (fun node -> Memo.Lazy.force node) in
   let both =
     Memo.Lazy.create (fun () ->
-      Memo.Build.fork_and_join_unit
-        (fun () -> Lazy.force cycle1)
-        (fun () -> Lazy.force cycle2)
-    )
+        Memo.Build.fork_and_join_unit
+          (fun () -> Lazy.force cycle1)
+          (fun () -> Lazy.force cycle2))
   in
   run_and_log_errors (Memo.Lazy.force both);
-  (* Even though these errors look similar, they are actually talking about two different
-     cycles which can be distinguished by the internal node ids, so they are not
-     deduplicated. *)
-  [%expect {|
+  (* Even though these errors look similar, they are actually talking about two
+     different cycles which can be distinguished by the internal node ids, so
+     they are not deduplicated. *)
+  [%expect
+    {|
     Error: { exn =
                "Memo.Error.E\n\
                \  { exn = \"Cycle_error.E [ (\\\"<unnamed>\\\", ()); (\\\"<unnamed>\\\", ()) ]\"\n\
@@ -1235,7 +1225,6 @@ let%expect_test "two similar, but not physically-equal, cycle errors" =
                \  }"
            ; backtrace = ""
            } |}]
-
 
 let%expect_test "Nested nodes with cutoff are recomputed optimally" =
   let counter = create ~with_cutoff:false "counter" (count_runs "counter") in


### PR DESCRIPTION
Make pretty-printing a dependency cycle a responsibility of the Report_error module instead of Build_system.
It's weird to have build_system.ml responsible for this bit of error handling. It should either live in Memo, which is producing the error and has sufficient knowledge to pretty-print it, or in Report_error, as this PR does.